### PR TITLE
mxm_wifiex: fix build error on kernel higher than L5.17

### DIFF
--- a/mxm_wifiex/wlan_src/mlinux/moal_debug.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_debug.c
@@ -743,7 +743,9 @@ static int woal_histogram_read(struct seq_file *sfp, void *data)
 
 static int woal_histogram_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_histogram_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_histogram_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_histogram_read, PDE(inode)->data);
@@ -942,7 +944,9 @@ static int woal_log_read(struct seq_file *sfp, void *data)
  */
 static int woal_log_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_log_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_log_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_log_read, PDE(inode)->data);
@@ -1266,7 +1270,9 @@ static ssize_t woal_debug_write(struct file *f, const char __user *buf,
 
 static int woal_debug_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_debug_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_debug_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_debug_read, PDE(inode)->data);

--- a/mxm_wifiex/wlan_src/mlinux/moal_ioctl.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_ioctl.c
@@ -845,8 +845,12 @@ mlan_status woal_request_set_mac_address(moal_private *priv, t_u8 wait_option)
 		       "set mac address failed! status=%d, error_code=0x%x\n",
 		       status, req->status_code);
 	} else {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+		dev_addr_mod(priv->netdev, 0, priv->current_addr, ETH_ALEN);
+#else
 		moal_memcpy_ext(priv->phandle, priv->netdev->dev_addr,
 				priv->current_addr, ETH_ALEN, ETH_ALEN);
+#endif
 		HEXDUMP("priv->MacAddr:", priv->current_addr, ETH_ALEN);
 	}
 done:
@@ -1872,8 +1876,12 @@ mlan_status woal_request_get_fw_info(moal_private *priv, t_u8 wait_option,
 			moal_memcpy_ext(priv->phandle, priv->current_addr,
 					&info->param.fw_info.mac_addr,
 					sizeof(mlan_802_11_mac_addr), ETH_ALEN);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+		dev_addr_mod(priv->netdev, 0, priv->current_addr, ETH_ALEN);
+#else
 		moal_memcpy_ext(priv->phandle, priv->netdev->dev_addr,
 				priv->current_addr, ETH_ALEN, ETH_ALEN);
+#endif
 		if (fw_info)
 			moal_memcpy_ext(priv->phandle, fw_info,
 					&info->param.fw_info,

--- a/mxm_wifiex/wlan_src/mlinux/moal_main.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_main.c
@@ -2312,6 +2312,15 @@ static t_u32 woal_process_init_cfg(moal_handle *handle, t_u8 *data, t_size size)
 							       "Set MAC address failed\n");
 							goto done;
 						}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+						dev_addr_mod(
+							handle->priv[i]
+								->netdev,
+							0,
+							handle->priv[i]
+								->current_addr,
+							ETH_ALEN);
+#else
 						moal_memcpy_ext(
 							handle,
 							handle->priv[i]
@@ -2320,6 +2329,7 @@ static t_u32 woal_process_init_cfg(moal_handle *handle, t_u8 *data, t_size size)
 							handle->priv[i]
 								->current_addr,
 							ETH_ALEN, ETH_ALEN);
+#endif
 						index++; /* Mark found one
 							    interface matching
 							  */
@@ -5174,8 +5184,12 @@ int woal_set_mac_address(struct net_device *dev, void *addr)
 		goto done;
 	}
 	HEXDUMP("priv->MacAddr:", priv->current_addr, ETH_ALEN);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	dev_addr_mod(dev, 0, priv->current_addr, ETH_ALEN);
+#else
 	moal_memcpy_ext(priv->phandle, dev->dev_addr, priv->current_addr,
 			ETH_ALEN, ETH_ALEN);
+#endif
 done:
 	LEAVE();
 	return ret;
@@ -6614,8 +6628,12 @@ void woal_init_priv(moal_private *priv, t_u8 wait_option)
 	}
 
 	woal_request_set_mac_address(priv, MOAL_IOCTL_WAIT);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	dev_addr_mod(priv->netdev, 0, priv->current_addr, ETH_ALEN);
+#else
 	moal_memcpy_ext(priv->phandle, priv->netdev->dev_addr,
 			priv->current_addr, ETH_ALEN, ETH_ALEN);
+#endif
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
 	priv->host_mlme = 0;
 	priv->auth_flag = 0;

--- a/mxm_wifiex/wlan_src/mlinux/moal_proc.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_proc.c
@@ -358,7 +358,9 @@ exit:
 
 static int woal_info_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_info_proc_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_info_proc_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_info_proc_read, PDE(inode)->data);
@@ -776,7 +778,9 @@ static int woal_config_read(struct seq_file *sfp, void *data)
 
 static int woal_config_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_config_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_config_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_config_read, PDE(inode)->data);
@@ -851,7 +855,9 @@ done:
 
 static int woal_drv_dump_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_drv_dump_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_drv_dump_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_drv_dump_read, PDE(inode)->data);
@@ -928,7 +934,9 @@ done:
 
 static int woal_fw_dump_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_fw_dump_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_fw_dump_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_fw_dump_read, PDE(inode)->data);
@@ -978,7 +986,9 @@ static int woal_wifi_status_read(struct seq_file *sfp, void *data)
 
 static int woal_wifi_status_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	return single_open(file, woal_wifi_status_read, pde_data(inode));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	return single_open(file, woal_wifi_status_read, PDE_DATA(inode));
 #else
 	return single_open(file, woal_wifi_status_read, PDE(inode)->data);

--- a/mxm_wifiex/wlan_src/mlinux/moal_shim.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_shim.c
@@ -2679,8 +2679,12 @@ mlan_status moal_recv_event(t_void *pmoal, pmlan_event pmevent)
 		woal_start_queue(priv->netdev);
 		moal_memcpy_ext(priv->phandle, priv->current_addr,
 				pmevent->event_buf + 6, ETH_ALEN, ETH_ALEN);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+		dev_addr_mod(priv->netdev, 0, priv->current_addr, ETH_ALEN);
+#else
 		moal_memcpy_ext(priv->phandle, priv->netdev->dev_addr,
 				priv->current_addr, ETH_ALEN, ETH_ALEN);
+#endif
 		woal_broadcast_event(priv, pmevent->event_buf,
 				     pmevent->event_len);
 #ifdef STA_SUPPORT


### PR DESCRIPTION
Since linux v5.17 `PDE_DATA()` is removed completely and replaced with
`pde_data()`: 359745d78351 ("proc: remove PDE_DATA() completely")

`*dev_addr` is set to `const` and a function to modify the address is
provided: adeef3e32146 ("net: constify netdev->dev_addr ")
