### PR TITLE
Fixes for Linux 6.1.y API change

### DIFF
--- a/mxm_wifiex/wlan_src/.gitignore
+++ b/mxm_wifiex/wlan_src/.gitignore
@@ -1,0 +1,9 @@
+*.cmd
+*.d
+*.o
+*.ko
+*.mod
+*.mod.c
+*.swp
+Module.symvers
+modules.order

--- a/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.c
@@ -1375,6 +1375,9 @@ fail:
  */
 #endif
 int woal_cfg80211_add_key(struct wiphy *wiphy, struct net_device *netdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			  int link_id,
+#endif
 			  t_u8 key_index,
 #if KERNEL_VERSION(2, 6, 36) < CFG80211_VERSION_CODE
 			  bool pairwise,
@@ -1431,6 +1434,9 @@ int woal_cfg80211_add_key(struct wiphy *wiphy, struct net_device *netdev,
  */
 #endif
 int woal_cfg80211_del_key(struct wiphy *wiphy, struct net_device *netdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			  int link_id,
+#endif
 			  t_u8 key_index,
 #if KERNEL_VERSION(2, 6, 36) < CFG80211_VERSION_CODE
 			  bool pairwise,
@@ -1486,7 +1492,11 @@ int woal_cfg80211_del_key(struct wiphy *wiphy, struct net_device *netdev,
  */
 #endif
 int woal_cfg80211_set_default_key(struct wiphy *wiphy,
-				  struct net_device *netdev, t_u8 key_index
+				  struct net_device *netdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+				  int link_id,
+#endif
+				  t_u8 key_index
 #if KERNEL_VERSION(2, 6, 37) < CFG80211_VERSION_CODE
 				  ,
 				  bool ucast, bool mcast
@@ -1518,6 +1528,9 @@ int woal_cfg80211_set_default_key(struct wiphy *wiphy,
 #if KERNEL_VERSION(2, 6, 30) <= CFG80211_VERSION_CODE
 int woal_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
 				       struct net_device *netdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			               int link_id,
+#endif
 				       t_u8 key_index)
 {
 	PRINTM(MINFO, "set default mgmt key, key index=%d\n", key_index);
@@ -1529,6 +1542,9 @@ int woal_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
 #if KERNEL_VERSION(5, 10, 0) <= CFG80211_VERSION_CODE
 int woal_cfg80211_set_default_beacon_key(struct wiphy *wiphy,
 					 struct net_device *netdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+					 int link_id,
+#endif
 					 t_u8 key_index)
 {
 	PRINTM(MINFO, "set default beacon key, key index=%d\n", key_index);

--- a/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.c
@@ -2817,7 +2817,11 @@ int woal_cfg80211_mgmt_tx(struct wiphy *wiphy,
 #if KERNEL_VERSION(3, 8, 0) > LINUX_VERSION_CODE
 	*cookie = random32() | 1;
 #else
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	*cookie = get_random_u32() | 1;
+#else
 	*cookie = prandom_u32() | 1;
+#endif
 #endif
 	pmbuf->data_offset = MLAN_MIN_DATA_HEADER_LEN;
 	pkt_type = MRVL_PKT_TYPE_MGMT_FRAME;

--- a/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.h
+++ b/mxm_wifiex/wlan_src/mlinux/moal_cfg80211.h
@@ -121,6 +121,9 @@ int woal_cfg80211_change_virtual_intf(struct wiphy *wiphy,
 int woal_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed);
 
 int woal_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			  int link_id,
+#endif
 			  t_u8 key_index,
 #if KERNEL_VERSION(2, 6, 36) < CFG80211_VERSION_CODE
 			  bool pairwise,
@@ -128,6 +131,9 @@ int woal_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
 			  const t_u8 *mac_addr, struct key_params *params);
 
 int woal_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			  int link_id,
+#endif
 			  t_u8 key_index,
 #if KERNEL_VERSION(2, 6, 36) < CFG80211_VERSION_CODE
 			  bool pairwise,
@@ -203,6 +209,9 @@ int woal_cfg80211_set_channel(struct wiphy *wiphy,
 
 #if KERNEL_VERSION(2, 6, 37) < CFG80211_VERSION_CODE
 int woal_cfg80211_set_default_key(struct wiphy *wiphy, struct net_device *dev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+				  int link_id,
+#endif
 				  t_u8 key_index, bool ucast, bool mcast);
 #else
 int woal_cfg80211_set_default_key(struct wiphy *wiphy, struct net_device *dev,
@@ -212,12 +221,18 @@ int woal_cfg80211_set_default_key(struct wiphy *wiphy, struct net_device *dev,
 #if KERNEL_VERSION(2, 6, 30) <= CFG80211_VERSION_CODE
 int woal_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
 				       struct net_device *netdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+			               int link_id,
+#endif
 				       t_u8 key_index);
 #endif
 
 #if KERNEL_VERSION(5, 10, 0) <= CFG80211_VERSION_CODE
 int woal_cfg80211_set_default_beacon_key(struct wiphy *wiphy,
 					 struct net_device *netdev,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+					 int link_id,
+#endif
 					 t_u8 key_index);
 #endif
 

--- a/mxm_wifiex/wlan_src/mlinux/moal_ioctl.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_ioctl.c
@@ -2738,7 +2738,7 @@ done:
  *  @return        MLAN_STATUS_SUCCESS/MLAN_STATUS_PENDING -- success, otherwise
  * fail
  */
-static mlan_status woal_set_ipv6_ra_offload(moal_handle *handle, t_u8 enable)
+static mlan_status __maybe_unused woal_set_ipv6_ra_offload(moal_handle *handle, t_u8 enable)
 {
 	mlan_status ret = MLAN_STATUS_SUCCESS;
 	moal_private *priv = NULL;
@@ -2794,7 +2794,7 @@ done:
  *  @return        MLAN_STATUS_SUCCESS/MLAN_STATUS_PENDING -- success, otherwise
  * fail
  */
-static mlan_status woal_set_ipv6_ns_offload(moal_handle *handle)
+static mlan_status __maybe_unused woal_set_ipv6_ns_offload(moal_handle *handle)
 {
 	mlan_status ret = MLAN_STATUS_SUCCESS;
 	mlan_ds_misc_cfg *misc = NULL;

--- a/mxm_wifiex/wlan_src/mlinux/moal_main.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_main.c
@@ -9358,7 +9358,11 @@ moal_handle *woal_add_card(void *card, struct device *dev, moal_if_ops *if_ops,
 #define NAPI_BUDGET 64
 	if (moal_extflg_isset(handle, EXT_NAPI)) {
 		init_dummy_netdev(&handle->napi_dev);
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		netif_napi_add_weight(&handle->napi_dev, &handle->napi_rx,
+#else
 		netif_napi_add(&handle->napi_dev, &handle->napi_rx,
+#endif
 			       woal_netdev_poll_rx, NAPI_BUDGET);
 		napi_enable(&handle->napi_rx);
 	}

--- a/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
@@ -5939,7 +5939,11 @@ woal_cfg80211_remain_on_channel(struct wiphy *wiphy, struct net_device *dev,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
 	*cookie = (u64)random32() | 1;
 #else
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	*cookie = get_random_u32() | 1;
+#else
 	*cookie = (u64)prandom_u32() | 1;
+#endif
 #endif
 	priv->phandle->remain_on_channel = MTRUE;
 	priv->phandle->remain_bss_index = priv->bss_index;


### PR DESCRIPTION
Kernel `6.1.y` is out, and this PR is a preparation for usage of this Driver together with updated API.

Commits 725bb20a68d630062c14bba5dd70e1783caf33ed and 93629b50cc357d36079569130decd6df0a4335d4 are not strictly related to it, but are addressing some "_cosmetics_" issues.

-- andrey