### PR TITLE
Fix kernel 6.5 compile issues for [leica/lf-6.1.22_2.0.0]

### DIFF
--- a/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
@@ -211,6 +211,9 @@ int woal_cfg80211_tdls_mgmt(struct wiphy *wiphy, struct net_device *dev,
 #else
 			    u8 *peer,
 #endif
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+			    int link_id,
+#endif
 			    u8 action_code, u8 dialog_token, u16 status_code,
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
 			    u32 peer_capability,
@@ -7475,7 +7478,11 @@ void woal_check_auto_tdls(struct wiphy *wiphy, struct net_device *dev)
 		spin_unlock_irqrestore(&priv->tdls_lock, flags);
 	}
 	if (tdls_discovery)
-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+		woal_cfg80211_tdls_mgmt(wiphy, dev, bcast_addr, 0,
+					TDLS_DISCOVERY_REQUEST, 1, 0, 0, 0,
+					NULL, 0);
+#elif CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
 		woal_cfg80211_tdls_mgmt(wiphy, dev, bcast_addr,
 					TDLS_DISCOVERY_REQUEST, 1, 0, 0, 0,
 					NULL, 0);
@@ -8213,7 +8220,13 @@ fail:
 	return ret;
 }
 
-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+int woal_cfg80211_tdls_mgmt(struct wiphy *wiphy, struct net_device *dev,
+			    const u8 *peer, int link_id, u8 action_code,
+			    u8 dialog_token, u16 status_code,
+			    u32 peer_capability, bool initiator,
+			    const u8 *extra_ies, size_t extra_ies_len)
+#elif CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
 /**
  * @brief Tx TDLS packet
  *

--- a/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
@@ -7475,16 +7475,14 @@ void woal_check_auto_tdls(struct wiphy *wiphy, struct net_device *dev)
 		spin_unlock_irqrestore(&priv->tdls_lock, flags);
 	}
 	if (tdls_discovery)
-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
 		woal_cfg80211_tdls_mgmt(wiphy, dev, bcast_addr,
 					TDLS_DISCOVERY_REQUEST, 1, 0, 0, 0,
 					NULL, 0);
-#else
+#elif CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
 		woal_cfg80211_tdls_mgmt(wiphy, dev, bcast_addr,
 					TDLS_DISCOVERY_REQUEST, 1, 0, 0, NULL,
 					0);
-#endif
 #else
 		woal_cfg80211_tdls_mgmt(wiphy, dev, bcast_addr,
 					TDLS_DISCOVERY_REQUEST, 1, 0, NULL, 0);
@@ -8237,8 +8235,7 @@ int woal_cfg80211_tdls_mgmt(struct wiphy *wiphy, struct net_device *dev,
 			    t_u16 status_code, t_u32 peer_capability,
 			    bool initiator, const t_u8 *extra_ies,
 			    size_t extra_ies_len)
-#else
-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
+#elif CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 15, 0)
 /**
  * @brief Tx TDLS packet
  *
@@ -8282,7 +8279,6 @@ int woal_cfg80211_tdls_mgmt(struct wiphy *wiphy, struct net_device *dev,
 			    t_u8 *peer, u8 action_code, t_u8 dialog_token,
 			    t_u16 status_code, const t_u8 *extra_ies,
 			    size_t extra_ies_len)
-#endif
 #endif
 {
 	moal_private *priv = (moal_private *)woal_get_netdev_priv(dev);


### PR DESCRIPTION
This is a port of #9 targeting [`leica/lf-6.1.22_2.0.0`] branch.

Since upstream commit [`c6112046b1a9 ("wifi: cfg80211: make TDLS management link-aware")`](https://github.com/torvalds/linux/commit/c6112046b1a9c130c455ab0bbe74c3f41138693c), TDLS management API has additional link_id parameter which is missing in the implementation.

**Cc:** @bith3ad