### PR TITLE
wlan: lower loglevel of 'scan' messages

### DIFF
--- a/mxm_wifiex/wlan_src/mlan/mlan_scan.c
+++ b/mxm_wifiex/wlan_src/mlan/mlan_scan.c
@@ -3381,7 +3381,7 @@ static t_void wlan_scan_process_results(mlan_private *pmpriv)
 	 *   domain info command to the FW.
 	 */
 	wlan_11d_prepare_dnld_domain_info_cmd(pmpriv);
-	PRINTM(MMSG, "wlan: SCAN COMPLETED: scanned AP count=%d\n",
+	PRINTM(MINFO, "wlan: SCAN COMPLETED: scanned AP count=%d\n",
 	       pmadapter->num_in_scan_table);
 	LEAVE();
 }

--- a/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_sta_cfg80211.c
@@ -4790,7 +4790,7 @@ done:
 		priv->phandle->scan_priv = NULL;
 		spin_unlock_irqrestore(&priv->phandle->scan_req_lock, flags);
 	} else {
-		PRINTM(MMSG, "wlan: %s START SCAN\n", dev->name);
+		PRINTM(MINFO, "wlan: %s START SCAN\n", dev->name);
 		queue_delayed_work(
 			priv->phandle->evt_workqueue,
 			&priv->phandle->scan_timeout_work,
@@ -4806,7 +4806,7 @@ static void woal_cfg80211_abort_scan(struct wiphy *wiphy,
 {
 	moal_private *priv = (moal_private *)woal_get_netdev_priv(wdev->netdev);
 	ENTER();
-	PRINTM(MMSG, "wlan: ABORT SCAN start\n");
+	PRINTM(MINFO, "wlan: ABORT SCAN start\n");
 	woal_cancel_scan(priv, MOAL_IOCTL_WAIT);
 	LEAVE();
 	return;
@@ -6644,7 +6644,7 @@ int woal_cfg80211_sched_scan_start(struct wiphy *wiphy, struct net_device *dev,
 	       MAC2STR(priv->scan_cfg.random_mac));
 	if (MLAN_STATUS_SUCCESS ==
 	    woal_request_bgscan(priv, MOAL_IOCTL_WAIT, &priv->scan_cfg)) {
-		PRINTM(MMSG, "wlan: sched scan start\n");
+		PRINTM(MINFO, "wlan: sched scan start\n");
 		priv->sched_scanning = MTRUE;
 		priv->bg_scan_start = MTRUE;
 		priv->bg_scan_reported = MFALSE;
@@ -6675,7 +6675,7 @@ int woal_cfg80211_sched_scan_stop(struct wiphy *wiphy, struct net_device *dev
 {
 	moal_private *priv = (moal_private *)woal_get_netdev_priv(dev);
 	ENTER();
-	PRINTM(MMSG, "wlan: sched scan stop\n");
+	PRINTM(MINFO, "wlan: sched scan stop\n");
 	priv->sched_scanning = MFALSE;
 	woal_stop_bg_scan(priv, MOAL_NO_WAIT);
 	priv->bg_scan_start = MFALSE;


### PR DESCRIPTION
The kernel log gets flooded with
[50254.012069] wlan: mlan0 START SCAN
[50259.126808] wlan: SCAN COMPLETED: scanned AP count=62 

even on a low loglevel=5, and the Makefiles CONFIG_DEBUG=n is set
By lowering the loglevel in the PRINTM this is sidestepped.