### PR TITLE
moal: lower loglevel on canceled IOCTLs

### DIFF
--- a/mxm_wifiex/wlan_src/mlinux/moal_shim.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_shim.c
@@ -1033,13 +1033,19 @@ mlan_status moal_ioctl_complete(t_void *pmoal, pmlan_ioctl_req pioctl_req,
 		return MLAN_STATUS_SUCCESS;
 	}
 
-	if (status != MLAN_STATUS_SUCCESS && status != MLAN_STATUS_COMPLETE)
-		PRINTM(MERROR,
-		       "IOCTL failed: %p id=0x%x, sub_id=0x%x action=%d, status_code=0x%x\n",
-		       pioctl_req, pioctl_req->req_id,
-		       (*(t_u32 *)pioctl_req->pbuf), (int)pioctl_req->action,
-		       pioctl_req->status_code);
-	else
+	if (status != MLAN_STATUS_SUCCESS && status != MLAN_STATUS_COMPLETE) {
+		if (pioctl_req->status_code == MLAN_ERROR_CMD_CANCEL)
+			PRINTM(MIOCTL,
+						 "IOCTL canceled: %p id=0x%x, sub_id=0x%x action=%d",
+						 pioctl_req, pioctl_req->req_id,
+						 (*(t_u32 *)pioctl_req->pbuf), (int)pioctl_req->action);
+		else
+			PRINTM(MERROR,
+						 "IOCTL failed: %p id=0x%x, sub_id=0x%x action=%d, status_code=0x%x\n",
+						 pioctl_req, pioctl_req->req_id,
+						 (*(t_u32 *)pioctl_req->pbuf), (int)pioctl_req->action,
+						 pioctl_req->status_code);
+	} else
 		PRINTM(MIOCTL,
 		       "IOCTL completed: %p id=0x%x sub_id=0x%x, action=%d,  status=%d, status_code=0x%x\n",
 		       pioctl_req, pioctl_req->req_id,


### PR DESCRIPTION
differentiating between canceled and (other) error codes when ioctls return, to allow filtering of the former - less critical - messages.

on a platform with the sdiw416 driver, the syslog is spammed (caused by NetworkManagers background scans?) with:
 [26044.474378] IOCTL failed: 000000004c19f89a id=0x10000, sub_id=0x10003 action=1, status_code=0x80000007
 [26461.466493] IOCTL failed: 0000000026a4ff8d id=0x10000, sub_id=0x10003 action=1, status_code=0x80000007
 [26878.457690] IOCTL failed: 000000000e7b4e90 id=0x10000, sub_id=0x10003 action=1, status_code=0x80000007
 [27295.449279] IOCTL failed: 00000000afe5b883 id=0x10000, sub_id=0x10003 action=1, status_code=0x80000007
 [27712.440275] IOCTL failed: 000000005fd85230 id=0x10000, sub_id=0x10003 action=1, status_code=0x80000007
 [28129.427922] IOCTL failed: 0000000037e21359 id=0x10000, sub_id=0x10003 action=1, status_code=0x80000007
 [28544.421457] IOCTL failed: 0000000026a4ff8d id=0x10000, sub_id=0x10003 action=1, status_code=0x80000007

to be able to filter them out with the drvdbg mask, but keep the "actual errors", this patch lowers the loglevel of canceled message from error to ioctl
