### PR TITLE
moal_main: fix compiling for linux >= v6.6

### DIFF
--- a/mxm_wifiex/wlan_src/mlinux/moal_main.c
+++ b/mxm_wifiex/wlan_src/mlinux/moal_main.c
@@ -75,6 +75,10 @@ Change log:
 #endif
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+#include <net/netdev_rx_queue.h>
+#endif
+
 /********************************************************
 		 Global Variables
  ********************************************************/


### PR DESCRIPTION
Git commit 49e47a5b6145 ("net: move struct netdev_rx_queue out of netdevice.h") refactored the code, take that into account.