### PR TITLE
Linux 6.16 compatibility

### DIFF
--- a/mlinux/moal_main.h
+++ b/mlinux/moal_main.h
@@ -583,9 +583,17 @@ static inline void woal_mod_timer(pmoal_drv_timer timer,
 static inline void woal_cancel_timer(moal_drv_timer *timer)
 {
 	if (timer->timer_is_periodic || in_atomic() || irqs_disabled())
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete(&timer->tl);
+#else
 		del_timer(&timer->tl);
+#endif
 	else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+		timer_delete_sync(&timer->tl);
+#else
 		del_timer_sync(&timer->tl);
+#endif
 	timer->timer_is_canceled = MTRUE;
 	timer->time_period = 0;
 }

--- a/mlinux/moal_main.h
+++ b/mlinux/moal_main.h
@@ -509,7 +509,11 @@ static inline void woal_timer_handler(struct timer_list *t)
 {
 	// Coverity violation raised for kernel's API
 	// coverity[cert_arr39_c_violation:SUPPRESS]
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+	pmoal_drv_timer timer = timer_container_of(timer, t, tl);
+#else
 	pmoal_drv_timer timer = from_timer(timer, t, tl);
+#endif
 #else
 static inline void woal_timer_handler(unsigned long fcontext)
 {


### PR DESCRIPTION
Changes required to make the driver Linux v6.16 compatible.