### PR TITLE
cherry-pick: "mxm_wifiex: add timer_container_of support"

### DIFF
--- a/mlinux/moal_main.h
+++ b/mlinux/moal_main.h
@@ -549,7 +549,11 @@ static inline void woal_timer_handler(struct timer_list *t)
 {
 	// Coverity violation raised for kernel's API
 	// coverity[cert_arr39_c_violation:SUPPRESS]
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+	pmoal_drv_timer timer = timer_container_of(timer, t, tl);
+#else
 	pmoal_drv_timer timer = from_timer(timer, t, tl);
+#endif
 #else
 static inline void woal_timer_handler(unsigned long fcontext)
 {


### PR DESCRIPTION
cherry-picking a commit i missed when filtering the patches from `leica/lf-6.12.20_2.0.0` to create the new `leica/lf-6.18.2-1.0.0`